### PR TITLE
Increased maximum allowable zoom level

### DIFF
--- a/MACE_Frontend/src/components/map/index.tsx
+++ b/MACE_Frontend/src/components/map/index.tsx
@@ -12,12 +12,13 @@ import * as Types from "../../data-types/index";
 const { createRef } = React;
 const { ipcRenderer } = window.require("electron");
 
-const DEFAULT_CENTER: LatLng = new LatLng(-35.361196112174795, 149.15725708007815);
+//const DEFAULT_CENTER: LatLng = new LatLng(-35.361196112174795, 149.15725708007815);
+const DEFAULT_CENTER: LatLng = new LatLng(38.973735, -76.922113); // UMD F3
 // const DEFAULT_CENTER: LatLng = new LatLng(
 //   38.28454701883166,
 //   -76.66688919067384
 // );
-const DEFAULT_ZOOM = 14;
+const DEFAULT_ZOOM = 18;
 
 type Props = {
   context?: ContextType;
@@ -173,7 +174,7 @@ export default class MapView extends React.Component<Props, State> {
           this.props.onUpdateGoHerePts(e.latlng);
         }}
         minZoom={5}
-        maxZoom={18}
+        maxZoom={19}
         onZoomEnd={this.setZoom}
         animate={true}
         oncontextmenu={this.handleContextMenu}


### PR DESCRIPTION
- Set maximum allowable zoom level to 19
- Changed UMD F3 to the default center of the map

*NOTE*: The zoom on the current tiles we have is blurry. We can try a different tile set, although the ones we currently have are generally the most universal.